### PR TITLE
Fix #12 - Switch sessions metric to pull XML instead of JSON

### DIFF
--- a/get_auth_token.py
+++ b/get_auth_token.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import httplib, urllib, base64, socket, getpass, json
 
 # Grab user credentials


### PR DESCRIPTION
As reported in #12 (and reinforced with https://forums.plex.tv/discussion/238197/malformed-json-response-from-status-sessions-query), the `/status/sessions` endpoint now serves up malformed JSON.

This PR switches to pulling XML from that endpoint, which is recommended, and sets the stage for adapting all requests from JSON to XML at some point.

## Testing Details

```
[rickatnight11@<hostname> collectd-plex]$ ./plex.py --sessions <hostname> 32400 <omitted>
{'plugin_instance': u'<servername>', 'type_instance': 'sessions-total', 'full_name': 'plex-<servername>.sessions-total.value', 'value': 2}
{'plugin_instance': u'<servername>', 'type_instance': 'sessions-active', 'full_name': 'plex-<servername>.sessions-active.value', 'value': 0}
{'plugin_instance': u'<servername>', 'type_instance': 'sessions-inactive', 'full_name': 'plex-<servername>.sessions-inactive.value', 'value': 2}
```

```
[rickatnight11@<hostname> collectd-plex]$ ./plex.py --sessions <hostname> 32400 <omitted>
{'plugin_instance': u'<servername>', 'type_instance': 'sessions-total', 'full_name': 'plex-<servername>.sessions-total.value', 'value': 4}
{'plugin_instance': u'<servername>', 'type_instance': 'sessions-active', 'full_name': 'plex-<servername>.sessions-active.value', 'value': 1}
{'plugin_instance': u'<servername>', 'type_instance': 'sessions-inactive', 'full_name': 'plex-<servername>.sessions-inactive.value', 'value': 3}
```