### PR TITLE
Fix support for 1.3.2.3112 API changes (fixed #18)

### DIFF
--- a/plex.py
+++ b/plex.py
@@ -122,18 +122,30 @@ def get_sections():
 
     sectionobject = api_request('/library/sections')
 
+    apimatched = False
+
     # Old PMS < 1.2.6 schema
     if '_children' in sectionobject:
-        sections = {}
-        for section in sectionobject['_children']:
-            sections[section['key']] = section
-        return sections
-    # Newer PMS 1.2.6+ schema
+        apimatched = True
+        api_sections = sectionobject['_children']
+    # Newer PMS 1.2.6+ schemas
     elif 'MediaContainer' in sectionobject:
+        # PMS 1.3.0 schema
+        if 'Metadata' in sectionobject['MediaContainer']:
+            apimatched = True
+            api_sections = sectionobject['MediaContainer']['Metadata']
+        # PMS 1.3.2 schema
+        elif 'Directory' in sectionobject['MediaContainer']:
+            apimatched = True
+            api_sections = sectionobject['MediaContainer']['Directory']
+
+    # Parse sections
+    if apimatched:
         sections = {}
-        for section in sectionobject['MediaContainer']['Metadata']:
+        for section in api_sections:
             sections[section['key']] = section
         return sections
+
     # Unknown format
     errormessage('PMS API returned unexpected format from "/library/sections"')
     return False


### PR DESCRIPTION
This _should_ maintain backwards compatibility with the previous 2 x API schemas, but I haven't explicitly tested them.

## Before

```
$ ./plex.py --movies <hostname> 32400 <apikey>
Traceback (most recent call last):
  File "./plex.py", line 330, in <module>
    get_metrics(collectd=False)
  File "./plex.py", line 34, in get_metrics
    sections = get_sections()
  File "./plex.py", line 135, in get_sections
    for section in sectionobject['MediaContainer']['Metadata']:
KeyError: 'Metadata'
```

## After

**Movies:**

```
$ ./plex.py --movies <hostname> 32400 <apikey>
{'plugin_instance': u'<servername>', 'type_instance': 'movies-1', 'full_name': 'plex-<servername>.movies-1.value', 'value': 2454}
{'plugin_instance': u'<servername>', 'type_instance': 'movies-13', 'full_name': 'plex-<servername>.movies-13.value', 'value': 1}
```

**Shows:**

```
$ ./plex.py --shows <hostname> 32400 <apikey>
{'plugin_instance': u'<servername>', 'type_instance': 'shows-2', 'full_name': 'plex-<servername>.shows-2.value', 'value': 593}
```

**Episodes:**

```
$ ./plex.py --episodes <hostname> 32400 <apikey>
{'plugin_instance': u'<servername>', 'type_instance': 'episodes-2', 'full_name': 'plex-<servername>.episodes-2.value', 'value': 33097}
```

**Sessions:** (don't use this code-path, but why not)

```
$ ./plex.py --sessions <hostname> 32400 <apikey>
{'plugin_instance': u'<servername>', 'type_instance': 'sessions-total', 'full_name': 'plex-<servername>.sessions-total.value', 'value': 8}
{'plugin_instance': u'<servername>', 'type_instance': 'sessions-active', 'full_name': 'plex-<servername>.sessions-active.value', 'value': 3}
{'plugin_instance': u'<servername>', 'type_instance': 'sessions-inactive', 'full_name': 'plex-<servername>.sessions-inactive.value', 'value': 5}
```