### PR TITLE
Remote Access status

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ metrics as library size (movies, shows, episodes) and active sessions.
 * `Movies` - collect movie counts (defaults to `True`)
 * `Shows` - collect show counts (defaults to `True`)
 * `Episodes` - collect episode counts (defaults to `True`)
+* `MyPlex` - collect remote access status (defaults to `False`)
 * `Include` - sections to collect media counts for (assumes all, if excluded)
 * `Exclude` - sections to ignore media counts for (assumes all, if excluded)
 
@@ -82,3 +83,35 @@ being collected.
 
 </Plugin>
 ```
+
+### Collect Remote Access status
+
+This configuration will monitor all metrics, plus Remote Access (MyPlex/Plex.tv) status.
+
+```
+<LoadPlugin python>
+  Globals true
+</LoadPlugin>
+
+<Plugin python>
+  ModulePath "/path/to/plugin"
+  Import "plex"
+
+  <Module plex>
+    Host "localhost"
+    Port 32400
+    AuthToken <token>
+    MyPlex true
+  </Module>
+
+</Plugin>
+```
+
+Reported values will be:
+
+| Value | Meaning                                                |
+|-------|--------------------------------------------------------|
+| -1    | Error (not logged in to Plex account on the server?)   |
+| 0     | Unreachable                                            |
+| 1     | Waiting (server is trying to connect to Remote Access) |
+| 2     | Reachable                                              |


### PR DESCRIPTION
This PR adds the Remote Access status metric (see [Plex's docs](https://support.plex.tv/hc/en-us/articles/200484543-Enabling-Remote-Access-for-a-Server)), under the type name of `remote-reachability` (as found in [PlexPy](https://github.com/JonnyWong16/plexpy/blob/master/plexpy/pmsconnect.py#L424)).

Correspondence to values (`[-1:2]`) has been addedd to the README, along with another configuration example.

---

Here is my Grafana panel that uses the new metric:

![grafana1](https://user-images.githubusercontent.com/3594528/30459750-da4e088a-99b2-11e7-97cf-f4f11c063aed.png)
![grafana2](https://user-images.githubusercontent.com/3594528/30459751-da4eb064-99b2-11e7-931c-3a36a6265f2d.png)
![grafana3](https://user-images.githubusercontent.com/3594528/30459749-da4b5284-99b2-11e7-8779-945b3975546f.png)
![grafana4](https://user-images.githubusercontent.com/3594528/30459752-da52d216-99b2-11e7-8421-32244b377bfc.png)



